### PR TITLE
#31: fixes starting from VS2019 Preview v16.2.0

### DIFF
--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -7,6 +7,10 @@
 
 These are the changes to each version that has been released on the official Visual Studio extension gallery.
 
+## 1.2.2 `(2019-05-23)`
+
+- [x] Fixed [#31](https://github.com/dmitry-pavlov/openapi-connected-service/issues/31) with [PR 35](https://github.com/dmitry-pavlov/openapi-connected-service/pull/35/)
+
 ## 1.2.1 `(2019-03-09)`
 
 - [x] Updated NuGet dependencies

--- a/src/OpenApiConnectedService.Package/source.extension.vsixmanifest
+++ b/src/OpenApiConnectedService.Package/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="DmitryPavlov.OpenApiConnectedService.13263952-1111-3333-2017-BA783BFD905A" Version="1.2.1" Language="en-US" Publisher="Dmitry Pavlov" />
+        <Identity Id="DmitryPavlov.OpenApiConnectedService.13263952-1111-3333-2017-BA783BFD905A" Version="1.2.2" Language="en-US" Publisher="Dmitry Pavlov" />
         <DisplayName>OpenAPI (Swagger) Connected Service</DisplayName>
         <Description>Connected service for Visual Studio to generate OpenAPI (Swagger) web service reference.</Description>
         <MoreInfo>https://github.com/dmitry-pavlov/openapi-connected-service</MoreInfo>


### PR DESCRIPTION
Fixes #31 in v1.2.2. Now extension works fine for Visual Studio 2019. 

Verified in: 
- Visual Studio Enterprise 2019 Preview Version 16.2.0 Preview 1.0 (now works as expected)
- Visual Studio Community 2019 Preview Version 16.2.0 Preview 1.0 (now works as expected)
- Visual Studio Community 2017 Preview Version 15.9.12 (keeps working as before)